### PR TITLE
Type discovery improvements

### DIFF
--- a/Pocket.Container/TypeDiscovery.nuspec
+++ b/Pocket.Container/TypeDiscovery.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Pocket.TypeDiscovery</id>
     <title>Pocket.TypeDiscovery</title>
-    <version>0.3.13</version>
+    <version>0.4.0</version>
     <authors>jonsequitur</authors>
     <owners></owners>
     <projectUrl>https://github.com/jonsequitur/PocketContainer</projectUrl>

--- a/Pocket.Container/netstandard2.0/Discover.cs
+++ b/Pocket.Container/netstandard2.0/Discover.cs
@@ -18,18 +18,31 @@ namespace Pocket
 #endif
     internal static class Discover
     {
+        /// <summary>
+        ///  Filters to types that can be instantiated.
+        /// </summary>
         public static IEnumerable<Type> Concrete(this IEnumerable<Type> types) =>
-            types
-                .Where(t => !t.IsAbstract &&
-                            !t.IsInterface &&
-                            !t.IsGenericTypeDefinition);
+            types.Where(t => !t.IsAbstract &&
+                             !t.IsEnum &&
+                             !typeof(Delegate).IsAssignableFrom(t) &&
+                             !t.IsInterface &&
+                             !t.IsGenericTypeDefinition);
 
-        public static IEnumerable<Type> DerivedFrom(this IEnumerable<Type> types, Type type) =>
-            types.Where(type.IsAssignableFrom);
-
+        /// <summary>
+        /// Discovers concrete types within the current AppDomain.
+        /// </summary>
         public static IEnumerable<Type> ConcreteTypes() =>
             Types().Concrete();
 
+        /// <summary>
+        /// Filters to types that are derived from the specified type.
+        /// </summary>
+        public static IEnumerable<Type> DerivedFrom(this IEnumerable<Type> types, Type type) =>
+            types.Where(type.IsAssignableFrom);
+
+        /// <summary>
+        /// Filters to types that implement a generic variant of one of the specified open generic interfaces.
+        /// </summary>
         public static IEnumerable<Type> ImplementingOpenGenericInterfaces(
             this IEnumerable<Type> source,
             params Type[] interfaces) =>
@@ -37,6 +50,9 @@ namespace Pocket
                                .Any(i => i.IsConstructedGenericType &&
                                          interfaces.Contains(i.GetGenericTypeDefinition())));
 
+        /// <summary>
+        /// Gets types within the current AppDomain.
+        /// </summary>
         public static IEnumerable<Type> Types() =>
             AppDomain.CurrentDomain
                      .GetAssemblies()
@@ -44,6 +60,9 @@ namespace Pocket
                      .Where(a => !a.GlobalAssemblyCache)
                      .Types();
 
+        /// <summary>
+        /// Gets types within the specified assemblies.
+        /// </summary>
         public static IEnumerable<Type> Types(this IEnumerable<Assembly> assemblies) =>
             assemblies.SelectMany(a =>
             {

--- a/Pocket.Container/netstandard2.0/Discover.cs
+++ b/Pocket.Container/netstandard2.0/Discover.cs
@@ -18,14 +18,17 @@ namespace Pocket
 #endif
     internal static class Discover
     {
+        public static IEnumerable<Type> Concrete(this IEnumerable<Type> types) =>
+            types
+                .Where(t => !t.IsAbstract &&
+                            !t.IsInterface &&
+                            !t.IsGenericTypeDefinition);
+
         public static IEnumerable<Type> DerivedFrom(this IEnumerable<Type> types, Type type) =>
             types.Where(type.IsAssignableFrom);
 
         public static IEnumerable<Type> ConcreteTypes() =>
-            Types()
-                .Where(t => !t.IsAbstract &&
-                            !t.IsInterface &&
-                            !t.IsGenericTypeDefinition);
+            Types().Concrete();
 
         public static IEnumerable<Type> ImplementingOpenGenericInterfaces(
             this IEnumerable<Type> source,
@@ -39,25 +42,28 @@ namespace Pocket
                      .GetAssemblies()
                      .Where(a => !a.IsDynamic)
                      .Where(a => !a.GlobalAssemblyCache)
-                     .SelectMany(a =>
-                     {
-                         try
-                         {
-                             return a.DefinedTypes;
-                         }
-                         catch (TypeLoadException)
-                         {
-                         }
-                         catch (ReflectionTypeLoadException)
-                         {
-                         }
-                         catch (FileNotFoundException)
-                         {
-                         }
-                         catch (FileLoadException)
-                         {
-                         }
-                         return Enumerable.Empty<Type>();
-                     });
+                     .Types();
+
+        public static IEnumerable<Type> Types(this IEnumerable<Assembly> assemblies) =>
+            assemblies.SelectMany(a =>
+            {
+                try
+                {
+                    return a.DefinedTypes;
+                }
+                catch (TypeLoadException)
+                {
+                }
+                catch (ReflectionTypeLoadException)
+                {
+                }
+                catch (FileNotFoundException)
+                {
+                }
+                catch (FileLoadException)
+                {
+                }
+                return Enumerable.Empty<Type>();
+            });
     }
 }

--- a/Pocket.TypeDiscovery.NetStandard2.0.Tests/TypeDiscoveryTests.cs
+++ b/Pocket.TypeDiscovery.NetStandard2.0.Tests/TypeDiscoveryTests.cs
@@ -25,6 +25,24 @@ namespace Pocket.TypeDiscovery.Tests
         }
 
         [Fact]
+        public void Concrete_types_does_not_include_static_classes()
+        {
+            Discover.ConcreteTypes().Should().NotContain(t => t == typeof(StaticClass));
+        }
+
+        [Fact]
+        public void Concrete_types_does_not_include_delegates()
+        {
+            Discover.ConcreteTypes().Should().NotContain(t => t == typeof(ADelegate));
+        }
+
+        [Fact]
+        public void Concrete_types_does_not_include_enums()
+        {
+            Discover.ConcreteTypes().Should().NotContain(t => t == typeof(Enum));
+        }
+
+        [Fact]
         public void DerivedFrom_returns_classes_implementing_the_specified_interface()
         {
             Discover.ConcreteTypes()
@@ -81,5 +99,15 @@ namespace Pocket.TypeDiscovery.Tests
         public interface ICommandHandler<T>
         {
         }
+
+        public enum Enum
+        {
+        }
+
+        public static class StaticClass
+        {
+        }
+
+        public delegate void ADelegate();
     }
 }


### PR DESCRIPTION
* Extract some useful methods from the existing implementations
* Add more specificity to `Concrete` / `ConcreteTypes` to exclude enums and delegate types.
* Add documentation comments