### PR TITLE
ResolveOptional

### DIFF
--- a/Pocket.Container.Tests/PocketContainerOptionalParameterTests.cs
+++ b/Pocket.Container.Tests/PocketContainerOptionalParameterTests.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions;
 using Xunit;
 
@@ -5,6 +6,27 @@ namespace Pocket.Container.Tests
 {
     public class PocketContainerOptionalParameterTests
     {
+        [Fact]
+        public void Optional_parameters_for_non_primitive_types_are_resolved_when_registered()
+        {
+            var container = new PocketContainer()
+                .Register<IAmAnInterface>(c => new HasDefaultCtor());
+
+            var o = container.Resolve<TakesOptionalParamWithNoDefaultValue<IAmAnInterface>>();
+
+            o.OptionalValue.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void Optional_parameters_for_non_primitive_types_are_passed_null_when_not_registered()
+        {
+            var container = new PocketContainer();
+
+            var o = container.Resolve<TakesOptionalParamWithNoDefaultValue<IAmAnInterface>>();
+
+            o.OptionalValue.Should().BeNull();
+        }
+
         [Fact]
         public void Optional_struct_parameters_with_no_default_value_are_filled_correctly()
         {

--- a/Pocket.Container.Tests/PocketContainerTests.cs
+++ b/Pocket.Container.Tests/PocketContainerTests.cs
@@ -132,6 +132,46 @@ namespace Pocket.Container.Tests
         }
 
         [Fact]
+        public void ResolveOptional_returns_default_when_struct_is_unregistered()
+        {
+            var container = new PocketContainer();
+
+            var value = container.ResolveOptional<int>();
+
+            value.Should().Be(0);
+        }
+
+        [Fact(Skip = "TODO")]
+        public void ResolveOptional_returns_null_when_dependency_is_unresolvable()
+        {
+            var container = new PocketContainer();
+
+            var value = container.ResolveOptional<HasOneParamCtor<IAmAnInterface>>();
+
+            value.Should().BeNull();
+        }
+
+        [Fact]
+        public void ResolveOptional_returns_null_when_interface_is_unregistered()
+        {
+            var container = new PocketContainer();
+
+            var value = container.ResolveOptional<IAmAnInterface>();
+
+            value.Should().BeNull();
+        }
+
+        [Fact]
+        public void ResolveOptional_returns_null_when_delegate_type_is_unregistered()
+        {
+            var container = new PocketContainer();
+
+            var value = container.ResolveOptional<SomeDelegateType>();
+
+            value.Should().BeNull();
+        }
+
+        [Fact]
         public void When_the_same_type_is_registered_multiple_times_then_the_last_register_wins()
         {
             var container = new PocketContainer();

--- a/Pocket.Container.Tests/PocketContainerTests.cs
+++ b/Pocket.Container.Tests/PocketContainerTests.cs
@@ -132,7 +132,7 @@ namespace Pocket.Container.Tests
         }
 
         [Fact]
-        public void ResolveOptional_returns_default_when_struct_is_unregistered()
+        public void ResolveOptional_T_returns_default_when_struct_is_unregistered()
         {
             var container = new PocketContainer();
 
@@ -141,8 +141,32 @@ namespace Pocket.Container.Tests
             value.Should().Be(0);
         }
 
-        [Fact(Skip = "TODO")]
-        public void ResolveOptional_returns_null_when_dependency_is_unresolvable()
+        [Fact]
+        public void ResolveOptional_returns_default_when_struct_is_unregistered()
+        {
+            var container = new PocketContainer();
+
+            var value = container.ResolveOptional(typeof(int));
+
+            value.Should().Be(0);
+        }
+
+        [Fact]
+        public void A_type_can_be_resolved_as_optional_first_and_later_as_non_optional()
+        {
+            var container = new PocketContainer();
+
+            var optional = container.Resolve<HasOneOptionalParameterCtor<IAmAnInterface>>();
+            
+            optional.Value.Should().BeNull();
+
+            Action resolveNotOptional = () => container.Resolve<HasOneParamCtor<IAmAnInterface>>();
+
+            resolveNotOptional.ShouldThrow<ArgumentException>();
+        }
+
+        [Fact]
+        public void ResolveOptional_T_returns_null_when_dependency_is_unresolvable()
         {
             var container = new PocketContainer();
 
@@ -152,7 +176,17 @@ namespace Pocket.Container.Tests
         }
 
         [Fact]
-        public void ResolveOptional_returns_null_when_interface_is_unregistered()
+        public void ResolveOptional_returns_null_when_dependency_is_unresolvable()
+        {
+            var container = new PocketContainer();
+
+            var value = container.ResolveOptional(typeof(HasOneParamCtor<IAmAnInterface>));
+
+            value.Should().BeNull();
+        }
+
+        [Fact]
+        public void ResolveOptional_T_returns_null_when_interface_is_unregistered()
         {
             var container = new PocketContainer();
 
@@ -162,11 +196,31 @@ namespace Pocket.Container.Tests
         }
 
         [Fact]
-        public void ResolveOptional_returns_null_when_delegate_type_is_unregistered()
+        public void ResolveOptional_returns_null_when_interface_is_unregistered()
+        {
+            var container = new PocketContainer();
+
+            var value = container.ResolveOptional(typeof(IAmAnInterface));
+
+            value.Should().BeNull();
+        }
+
+        [Fact]
+        public void ResolveOptional_T_returns_null_when_delegate_type_is_unregistered()
         {
             var container = new PocketContainer();
 
             var value = container.ResolveOptional<SomeDelegateType>();
+
+            value.Should().BeNull();
+        }
+
+        [Fact]
+        public void ResolveOptional_returns_null_when_delegate_type_is_unregistered()
+        {
+            var container = new PocketContainer();
+
+            var value = container.ResolveOptional(typeof(SomeDelegateType));
 
             value.Should().BeNull();
         }

--- a/Pocket.Container/PocketContainer.nuspec
+++ b/Pocket.Container/PocketContainer.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>PocketContainer</id>
     <title>PocketContainer</title>
-    <version>1.6.2-beta</version>
+    <version>1.6.3-beta</version>
     <authors>jonsequitur</authors>
     <owners>jonsequitur</owners>
     <projectUrl>https://github.com/jonsequitur/pocketcontainer</projectUrl>


### PR DESCRIPTION
This adds a `ResolveOptional` method and uses it by default to pass optional constructor parameters.