### PR TITLE
add strategy to repalce object with test types

### DIFF
--- a/Pocket.Container.Test.Assembly/HttpClientSurrogate.cs
+++ b/Pocket.Container.Test.Assembly/HttpClientSurrogate.cs
@@ -2,9 +2,9 @@
 
 namespace Pocket.Container.Test.Assembly
 {
-    public class HttpClientrSurrogate : HttpClient
+    public class HttpClientSurrogate : HttpClient
     {
-        public HttpClientrSurrogate()
+        public HttpClientSurrogate()
         {
         }
     }

--- a/Pocket.Container.Test.Assembly/Pocket.Container.Test.Assembly.csproj
+++ b/Pocket.Container.Test.Assembly/Pocket.Container.Test.Assembly.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/Pocket.Container.Test.Assembly/StringBuilderSurroage.cs
+++ b/Pocket.Container.Test.Assembly/StringBuilderSurroage.cs
@@ -1,0 +1,11 @@
+﻿using System.Net.Http;
+
+namespace Pocket.Container.Test.Assembly
+{
+    public class HttpClientrSurrogate : HttpClient
+    {
+        public HttpClientrSurrogate()
+        {
+        }
+    }
+}

--- a/Pocket.Container.Tests/Pocket.Container.Tests.csproj
+++ b/Pocket.Container.Tests/Pocket.Container.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Pocket.Container.Test.Assembly\Pocket.Container.Test.Assembly.csproj" />
     <ProjectReference Include="..\Pocket.Container\Pocket.Container.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Pocket.Container.Tests/PocketContainerTestFakesStrategyTests.cs
+++ b/Pocket.Container.Tests/PocketContainerTestFakesStrategyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using Pocket.Container.Test.Assembly;
 using Xunit;
@@ -13,7 +14,7 @@ namespace Pocket.Container.Tests
         [Fact]
         public void When_looking_for_fakes_near_to_a_type_nested_class_is_preferred()
         {
-            var container = new PocketContainer().ResolveWithFakeTypesCloseTo(this);
+            var container = new PocketContainer().UseFakeTypesCloseTo(this);
 
             var resolved = container.Resolve<RealObject>();
             resolved.Should().NotBeNull();
@@ -23,7 +24,7 @@ namespace Pocket.Container.Tests
         [Fact]
         public void When_looking_for_fakes_near_to_a_type_the_closest_is_used()
         {
-            var container = new PocketContainer().ResolveWithFakeTypesCloseTo<RealObject>();
+            var container = new PocketContainer().UseFakeTypesCloseTo<RealObject>();
 
             var resolved = container.Resolve<RealObject>();
             resolved.Should().NotBeNull();
@@ -33,7 +34,7 @@ namespace Pocket.Container.Tests
         [Fact]
         public void When_looking_for_fakes_user_can_speficy_convention()
         {
-            var container = new PocketContainer().ResolveWithFakeTypesCloseTo<RealObject>("Surrogate");
+            var container = new PocketContainer().UseTypesCloseTo<RealObject>(t => Regex.IsMatch(t.Name, @".+Surrogate", RegexOptions.Compiled | RegexOptions.IgnoreCase));
 
             var resolved = container.Resolve<RealObject>();
             resolved.Should().NotBeNull();
@@ -43,7 +44,7 @@ namespace Pocket.Container.Tests
         [Fact]
         public void When_looking_for_fakes_near_to_a_type_user_can_speficy_convention()
         {
-            var container = new PocketContainer().ResolveWithFakeTypesCloseTo(this, "Surrogate");
+            var container = new PocketContainer().UseTypesCloseTo(this, t => Regex.IsMatch(t.Name, @".+Surrogate", RegexOptions.Compiled | RegexOptions.IgnoreCase));
 
             var resolved = container.Resolve<RealObject>();
             resolved.Should().NotBeNull();
@@ -53,7 +54,9 @@ namespace Pocket.Container.Tests
         [Fact]
         public void When_looking_for_fakes_they_can_be_constriained_to_a_specific_assembly()
         {
-            var container = new PocketContainer().ResolveWithFakeTypesFromAssembly(typeof(HttpClientSurrogate).Assembly, "Surrogate");
+            var container = new PocketContainer().UseTypesFromAssembly(
+                typeof(HttpClientSurrogate).Assembly, 
+                t => Regex.IsMatch(t.Name, @".+Surrogate", RegexOptions.Compiled | RegexOptions.IgnoreCase));
 
             var resolved = container.Resolve<HttpClient>();
             resolved.Should().NotBeNull();

--- a/Pocket.Container.Tests/PocketContainerTestFakesStrategyTests.cs
+++ b/Pocket.Container.Tests/PocketContainerTestFakesStrategyTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Http;
+using FluentAssertions;
+using Pocket.Container.Test.Assembly;
+using PocketContainer;
+using Xunit;
+
+namespace Pocket.Container.Tests
+{
+    public class PocketContainerTestFakesStrategyTests
+    {
+        [Fact]
+        public void When_looking_for_fakes_near_to_a_type_nested_class_is_preferred()
+        {
+            var container = new PocketContainer().ResolveWithFakeTypesCloseTo(this);
+
+            var resolved = container.Resolve<RealObject>();
+            resolved.Should().NotBeNull();
+            resolved.Should().BeOfType<RealObjectNestedFake>();
+        }
+
+        [Fact]
+        public void When_looking_for_fakes_near_to_a_type_the_closest_is_used()
+        {
+            var container = new PocketContainer().ResolveWithFakeTypesCloseTo<RealObject>();
+
+            var resolved = container.Resolve<RealObject>();
+            resolved.Should().NotBeNull();
+            resolved.Should().BeOfType<RealObjectFake>();
+        }
+
+        [Fact]
+        public void When_looking_for_fakes_in_a_specific_Assemly_closest_is_used()
+        {
+            var container = new PocketContainer().ResolveWithFakeTypesCloseTo<RealObject>();
+
+            var resolved = container.Resolve<RealObject>();
+            resolved.Should().NotBeNull();
+            resolved.Should().BeOfType<RealObjectFake>();
+        }
+
+        [Fact]
+        public void When_looking_for_fakes_user_can_speficy_convention()
+        {
+            var container = new PocketContainer().ResolveWithFakeTypesCloseTo<RealObject>("Surrogate");
+
+            var resolved = container.Resolve<RealObject>();
+            resolved.Should().NotBeNull();
+            resolved.Should().BeOfType<RealObjectSurrogate>();
+        }
+
+        [Fact]
+        public void When_looking_for_fakes_near_to_a_type_user_can_speficy_convention()
+        {
+            var container = new PocketContainer().ResolveWithFakeTypesCloseTo(this, "Surrogate");
+
+            var resolved = container.Resolve<RealObject>();
+            resolved.Should().NotBeNull();
+            resolved.Should().BeOfType<RealObjectSurrogate>();
+        }
+
+        [Fact]
+        public void When_looking_for_fakes_they_can_be_constriained_to_a_specific_assembly()
+        {
+            var container = new PocketContainer().ResolveWithFakeTypesFromAssembly(typeof(HttpClientrSurrogate).Assembly, "Surrogate");
+
+            var resolved = container.Resolve<HttpClient>();
+            resolved.Should().NotBeNull();
+            resolved.Should().BeOfType<HttpClientrSurrogate>();
+        }
+
+
+        public class RealObjectNestedFake : RealObject
+        {
+            public RealObjectNestedFake() : base("Value for tests - NESTED")
+            {
+            }
+        }
+
+        public class NestedContainer
+        {
+            public class RealObjectNestedNestedFake : RealObject
+            {
+                public RealObjectNestedNestedFake() : base("Value for tests - NESTED TWICE")
+                {
+                }
+            }
+        }
+    }
+
+    public class RealObject
+    {
+        public string RequiredValue { get; }
+
+        public RealObject(string requiredValue)
+        {
+            if (string.IsNullOrWhiteSpace(requiredValue))
+            {
+                throw new System.ArgumentException("message", nameof(requiredValue));
+            }
+
+            RequiredValue = requiredValue;
+        }
+    }
+
+    public class RealObjectFake : RealObject
+    {
+        public RealObjectFake() : base("Value for tests")
+        {
+        }
+    }
+
+    public class RealObjectSurrogate : RealObject
+    {
+        public RealObjectSurrogate() : base("Value for tests")
+        {
+        }
+    }
+}

--- a/Pocket.Container.Tests/PocketContainerTestFakesStrategyTests.cs
+++ b/Pocket.Container.Tests/PocketContainerTestFakesStrategyTests.cs
@@ -32,16 +32,6 @@ namespace Pocket.Container.Tests
         }
 
         [Fact]
-        public void When_looking_for_fakes_in_a_specific_Assemly_closest_is_used()
-        {
-            var container = new PocketContainer().ResolveWithFakeTypesCloseTo<RealObject>();
-
-            var resolved = container.Resolve<RealObject>();
-            resolved.Should().NotBeNull();
-            resolved.Should().BeOfType<RealObjectFake>();
-        }
-
-        [Fact]
         public void When_looking_for_fakes_user_can_speficy_convention()
         {
             var container = new PocketContainer().ResolveWithFakeTypesCloseTo<RealObject>("Surrogate");

--- a/Pocket.Container.Tests/PocketContainerTestFakesStrategyTests.cs
+++ b/Pocket.Container.Tests/PocketContainerTestFakesStrategyTests.cs
@@ -53,11 +53,11 @@ namespace Pocket.Container.Tests
         [Fact]
         public void When_looking_for_fakes_they_can_be_constriained_to_a_specific_assembly()
         {
-            var container = new PocketContainer().ResolveWithFakeTypesFromAssembly(typeof(HttpClientrSurrogate).Assembly, "Surrogate");
+            var container = new PocketContainer().ResolveWithFakeTypesFromAssembly(typeof(HttpClientSurrogate).Assembly, "Surrogate");
 
             var resolved = container.Resolve<HttpClient>();
             resolved.Should().NotBeNull();
-            resolved.Should().BeOfType<HttpClientrSurrogate>();
+            resolved.Should().BeOfType<HttpClientSurrogate>();
         }
 
 

--- a/Pocket.Container.Tests/PocketContainerTestFakesStrategyTests.cs
+++ b/Pocket.Container.Tests/PocketContainerTestFakesStrategyTests.cs
@@ -4,7 +4,6 @@
 using System.Net.Http;
 using FluentAssertions;
 using Pocket.Container.Test.Assembly;
-using PocketContainer;
 using Xunit;
 
 namespace Pocket.Container.Tests

--- a/Pocket.Container/Discover.cs
+++ b/Pocket.Container/Discover.cs
@@ -41,6 +41,12 @@ namespace Pocket
             types.Where(t => type != t && type.IsAssignableFrom(t));
 
         /// <summary>
+        /// Orders types by the distance from the specified type.
+        /// </summary>
+        public static IEnumerable<Type> CloseTo(this IEnumerable<Type> types, Type type) =>
+            types.OrderBy(t => t.DistanceFrom(type));
+
+        /// <summary>
         /// Filters to types that implement a generic variant of one of the specified open generic interfaces.
         /// </summary>
         public static IEnumerable<Type> ImplementingOpenGenericInterfaces(
@@ -84,5 +90,30 @@ namespace Pocket
                 }
                 return Enumerable.Empty<Type>();
             });
+  
+        private static int DistanceFrom(this Type queryType, Type targetType)
+        {
+
+            var distance = 0;
+            if (queryType.IsNested && queryType.DeclaringType == targetType)
+            {
+                return -1;
+            }
+            var sameAssmeby = targetType.Assembly == queryType.Assembly;
+            var targetTypePath = targetType.FullName.Split(new[] { '.', '+' }, StringSplitOptions.RemoveEmptyEntries);
+            var queryTypePath = queryType.FullName.Split(new[] { '.', '+' }, StringSplitOptions.RemoveEmptyEntries);
+            var scanLimit = Math.Min(queryTypePath.Length - 1, targetTypePath.Length);
+            var maxDistance = Math.Max(queryTypePath.Length - 1, targetTypePath.Length);
+            for (var i = 0; i < scanLimit; i++)
+            {
+                if (queryTypePath[i] != targetTypePath[i])
+                {
+                    distance = maxDistance - i;
+                    break;
+                }
+            }
+
+            return sameAssmeby ? distance : distance << 4;
+        }
     }
 }

--- a/Pocket.Container/Discover.cs
+++ b/Pocket.Container/Discover.cs
@@ -38,7 +38,7 @@ namespace Pocket
         /// Filters to types that are derived from the specified type.
         /// </summary>
         public static IEnumerable<Type> DerivedFrom(this IEnumerable<Type> types, Type type) =>
-            types.Where(type.IsAssignableFrom);
+            types.Where(t => type != t && type.IsAssignableFrom(t));
 
         /// <summary>
         /// Filters to types that implement a generic variant of one of the specified open generic interfaces.

--- a/Pocket.Container/PocketContainerTestFakesStrategy.cs
+++ b/Pocket.Container/PocketContainerTestFakesStrategy.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Pocket;
+
+namespace PocketContainer
+{
+#if !SourceProject
+    [System.Diagnostics.DebuggerStepThrough]
+#endif
+    internal static class PocketContainerTestFakesStrategy
+    {
+        public static Pocket.PocketContainer ResolveWithFakeTypesFromAssembly(
+            this Pocket.PocketContainer container, Assembly assembly)
+        {
+            return container.ResolveWithFakeTypesFromAssembly(assembly, "Fake");
+        }
+
+        public static Pocket.PocketContainer ResolveWithFakeTypesFromAssembly(
+            this Pocket.PocketContainer container, Assembly assembly, string convention)
+        {
+            if (container == null) throw new ArgumentNullException(nameof(container));
+            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+            if (string.IsNullOrWhiteSpace(convention))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(convention));
+
+            var conventionFilter = convention.ToLower(CultureInfo.InvariantCulture);
+
+            return container.AddStrategy(type =>
+            {
+                Type fake = null;
+                if (!type.FullName.EndsWith(conventionFilter, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var fakes = Discover
+                        .ConcreteTypes()
+                        .DerivedFrom(type)
+                        .Where(t => t.Assembly == assembly && t.FullName.EndsWith(conventionFilter,
+                                        StringComparison.InvariantCultureIgnoreCase))
+                        .OrderBy(t => TypeDistanceFrom(type, t))
+                        .ToArray();
+
+                    fake = fakes.FirstOrDefault();
+                }
+
+                if (fake != null)
+                {
+                    return c => c.Resolve(fake);
+                }
+                return null;
+            });
+        }
+
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo(
+            this Pocket.PocketContainer container, Type searchPoint)
+        {
+            return container.ResolveWithFakeTypesCloseTo(searchPoint, "Fake");
+        }
+
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(
+            this Pocket.PocketContainer container, T _)
+        {
+            return container.ResolveWithFakeTypesCloseTo<T>("Fake");
+        }
+
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(
+            this Pocket.PocketContainer container, T _, string convention)
+        {
+            return container.ResolveWithFakeTypesCloseTo<T>(convention);
+        }
+
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(
+            this Pocket.PocketContainer container)
+        {
+            return container.ResolveWithFakeTypesCloseTo<T>("Fake");
+        }
+
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(
+            this Pocket.PocketContainer container, string convention)
+        {
+            return container.ResolveWithFakeTypesCloseTo(typeof(T), convention);
+        }
+
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo(
+            this Pocket.PocketContainer container, Type searchPoint, string convention)
+        {
+            if (container == null) throw new ArgumentNullException(nameof(container));
+            if (searchPoint == null) throw new ArgumentNullException(nameof(searchPoint));
+            if (string.IsNullOrWhiteSpace(convention))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(convention));
+
+            var conventionFilter = convention.ToLower(CultureInfo.InvariantCulture);
+            return container.AddStrategy(type =>
+            {
+                Type fake = null;
+                if (!type.FullName.EndsWith(conventionFilter, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var fakes = Discover
+                        .ConcreteTypes()
+                        .DerivedFrom(type)
+                        .Where(t => t.FullName.EndsWith(conventionFilter, StringComparison.InvariantCultureIgnoreCase))
+                        .OrderBy(t => TypeDistanceFrom(searchPoint, t)).ToArray();
+                        
+                        fake = fakes.FirstOrDefault();
+
+                    
+                }
+                if (fake != null)
+                {
+                    return c => c.Resolve(fake);
+                }
+                return null;
+            });
+        }
+
+        private static int TypeDistanceFrom(Type searchPoint, Type element)
+        {
+            
+            var distance = 0;
+            if (element.IsNested && element.DeclaringType == searchPoint)
+            {
+                return distance;
+            }
+            var sameAssmeby = searchPoint.Assembly == element.Assembly;
+            var searchPointPath = searchPoint.FullName.Split(new[] {'.', '+'}, StringSplitOptions.RemoveEmptyEntries);
+            var elementPath = element.FullName.Split(new[] { '.', '+' }, StringSplitOptions.RemoveEmptyEntries);
+            var scanLimit = Math.Min(elementPath.Length - 1, searchPointPath.Length);
+            var maxDistance = Math.Max(elementPath.Length - 1, searchPointPath.Length);
+            for (var i = 0; i < scanLimit; i++)
+            {
+                if (elementPath[i] != searchPointPath[i])
+                {
+                    distance = maxDistance - i;
+                    break;
+                }
+            }
+
+            return distance = sameAssmeby ? distance : distance << 4;
+        }
+    }
+}

--- a/Pocket.Container/PocketContainerTestFakesStrategy.cs
+++ b/Pocket.Container/PocketContainerTestFakesStrategy.cs
@@ -68,10 +68,20 @@ namespace Pocket
 
         public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo(this Pocket.PocketContainer container, Type searchPoint, string convention)
         {
-            if (container == null) throw new ArgumentNullException(nameof(container));
-            if (searchPoint == null) throw new ArgumentNullException(nameof(searchPoint));
+            if (container == null)
+            {
+                throw new ArgumentNullException(nameof(container));
+            }
+
+            if (searchPoint == null)
+            {
+                throw new ArgumentNullException(nameof(searchPoint));
+            }
+
             if (string.IsNullOrWhiteSpace(convention))
+            {
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(convention));
+            }
 
             var conventionFilter = convention.ToLower(CultureInfo.InvariantCulture);
             return container.AddStrategy(type =>

--- a/Pocket.Container/PocketContainerTestFakesStrategy.cs
+++ b/Pocket.Container/PocketContainerTestFakesStrategy.cs
@@ -50,20 +50,21 @@ namespace Pocket
             });
         }
 
-        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo(this Pocket.PocketContainer container, Type searchPoint) 
-            => container.ResolveWithFakeTypesCloseTo(searchPoint, "Fake");
 
         public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(this Pocket.PocketContainer container, T _) 
-            => container.ResolveWithFakeTypesCloseTo<T>("Fake");
+            => container.ResolveWithFakeTypesCloseTo<T>();
 
         public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(this Pocket.PocketContainer container, T _, string convention) 
             => container.ResolveWithFakeTypesCloseTo<T>(convention);
 
         public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(this Pocket.PocketContainer container) 
-            => container.ResolveWithFakeTypesCloseTo<T>("Fake");
+            => container.ResolveWithFakeTypesCloseTo(typeof(T));
 
         public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(this Pocket.PocketContainer container, string convention) 
             => container.ResolveWithFakeTypesCloseTo(typeof(T), convention);
+        
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo(this Pocket.PocketContainer container, Type searchPoint)
+            => container.ResolveWithFakeTypesCloseTo(searchPoint, "Fake");
 
         public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo(this Pocket.PocketContainer container, Type searchPoint, string convention)
         {

--- a/Pocket.Container/PocketContainerTestFakesStrategy.cs
+++ b/Pocket.Container/PocketContainerTestFakesStrategy.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Reflection;
 using Pocket;
 
-namespace PocketContainer
+namespace Pocket
 {
 #if !SourceProject
     [System.Diagnostics.DebuggerStepThrough]

--- a/Pocket.Container/PocketContainerTestFakesStrategy.cs
+++ b/Pocket.Container/PocketContainerTestFakesStrategy.cs
@@ -14,14 +14,10 @@ namespace PocketContainer
 #endif
     internal static class PocketContainerTestFakesStrategy
     {
-        public static Pocket.PocketContainer ResolveWithFakeTypesFromAssembly(
-            this Pocket.PocketContainer container, Assembly assembly)
-        {
-            return container.ResolveWithFakeTypesFromAssembly(assembly, "Fake");
-        }
+        public static Pocket.PocketContainer ResolveWithFakeTypesFromAssembly(this Pocket.PocketContainer container, Assembly assembly) 
+            => container.ResolveWithFakeTypesFromAssembly(assembly, "Fake");
 
-        public static Pocket.PocketContainer ResolveWithFakeTypesFromAssembly(
-            this Pocket.PocketContainer container, Assembly assembly, string convention)
+        public static Pocket.PocketContainer ResolveWithFakeTypesFromAssembly(this Pocket.PocketContainer container, Assembly assembly, string convention)
         {
             if (container == null) throw new ArgumentNullException(nameof(container));
             if (assembly == null) throw new ArgumentNullException(nameof(assembly));
@@ -54,38 +50,22 @@ namespace PocketContainer
             });
         }
 
-        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo(
-            this Pocket.PocketContainer container, Type searchPoint)
-        {
-            return container.ResolveWithFakeTypesCloseTo(searchPoint, "Fake");
-        }
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo(this Pocket.PocketContainer container, Type searchPoint) 
+            => container.ResolveWithFakeTypesCloseTo(searchPoint, "Fake");
 
-        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(
-            this Pocket.PocketContainer container, T _)
-        {
-            return container.ResolveWithFakeTypesCloseTo<T>("Fake");
-        }
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(this Pocket.PocketContainer container, T _) 
+            => container.ResolveWithFakeTypesCloseTo<T>("Fake");
 
-        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(
-            this Pocket.PocketContainer container, T _, string convention)
-        {
-            return container.ResolveWithFakeTypesCloseTo<T>(convention);
-        }
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(this Pocket.PocketContainer container, T _, string convention) 
+            => container.ResolveWithFakeTypesCloseTo<T>(convention);
 
-        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(
-            this Pocket.PocketContainer container)
-        {
-            return container.ResolveWithFakeTypesCloseTo<T>("Fake");
-        }
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(this Pocket.PocketContainer container) 
+            => container.ResolveWithFakeTypesCloseTo<T>("Fake");
 
-        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(
-            this Pocket.PocketContainer container, string convention)
-        {
-            return container.ResolveWithFakeTypesCloseTo(typeof(T), convention);
-        }
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo<T>(this Pocket.PocketContainer container, string convention) 
+            => container.ResolveWithFakeTypesCloseTo(typeof(T), convention);
 
-        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo(
-            this Pocket.PocketContainer container, Type searchPoint, string convention)
+        public static Pocket.PocketContainer ResolveWithFakeTypesCloseTo(this Pocket.PocketContainer container, Type searchPoint, string convention)
         {
             if (container == null) throw new ArgumentNullException(nameof(container));
             if (searchPoint == null) throw new ArgumentNullException(nameof(searchPoint));
@@ -122,7 +102,7 @@ namespace PocketContainer
             var distance = 0;
             if (element.IsNested && element.DeclaringType == searchPoint)
             {
-                return distance;
+                return -1;
             }
             var sameAssmeby = searchPoint.Assembly == element.Assembly;
             var searchPointPath = searchPoint.FullName.Split(new[] {'.', '+'}, StringSplitOptions.RemoveEmptyEntries);
@@ -138,7 +118,7 @@ namespace PocketContainer
                 }
             }
 
-            return distance = sameAssmeby ? distance : distance << 4;
+            return sameAssmeby ? distance : distance << 4;
         }
     }
 }

--- a/Pocket.Container/PocketContainerTestFakesStrategy.nuspec
+++ b/Pocket.Container/PocketContainerTestFakesStrategy.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>PocketContainer.TestFakesStrategy</id>
+    <title>PocketContainer Test Fakes Strategy</title>
+    <version>1.0.0</version>
+    <authors>jonsequitur</authors>
+    <owners>jonsequitur</owners>
+    <projectUrl>https://github.com/jonsequitur/PocketContainer</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>A convention that will resolve a type when it is the fake of a real type.</description>
+    <tags>PocketContainer IoC DI container convention strategy</tags>
+    <developmentDependency>true</developmentDependency>
+    
+    <dependencies>
+      <dependency id="PocketContainer" version="[1.4.6,)" include="all" />
+      <dependency id="Pocket.TypeDiscovery" version="[0.3.0,1)" include="all" />
+    </dependencies>
+   
+    <licenseUrl>https://github.com/jonsequitur/PocketContainer/blob/master/LICENSE</licenseUrl>
+  </metadata>
+  <files>
+    <file src="PocketContainerTestFakesStrategy.cs" 
+          target="contentFiles/cs/any/(Pocket)/Container/PocketContainerTestFakesStrategy.cs" />
+  </files>
+</package>

--- a/PocketContainer.sln
+++ b/PocketContainer.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pocket.Container.Cumulative
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pocket.TypeDiscovery.Tests", "Pocket.TypeDiscovery.Tests\Pocket.TypeDiscovery.Tests.csproj", "{EB4F8356-7CC4-403B-83D7-9CF308852DDE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pocket.Container.Test.Assembly", "Pocket.Container.Test.Assembly\Pocket.Container.Test.Assembly.csproj", "{63B7EBE2-2283-41A9-B9EA-DF1ED4834989}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{EB4F8356-7CC4-403B-83D7-9CF308852DDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB4F8356-7CC4-403B-83D7-9CF308852DDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB4F8356-7CC4-403B-83D7-9CF308852DDE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63B7EBE2-2283-41A9-B9EA-DF1ED4834989}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63B7EBE2-2283-41A9-B9EA-DF1ED4834989}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63B7EBE2-2283-41A9-B9EA-DF1ED4834989}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63B7EBE2-2283-41A9-B9EA-DF1ED4834989}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Using this strategy users can intercept type resolutions and replace typeswith other ones based on conventions (by default a type T can be resolved to TFake) as long as the yderive from the type originally intented. Resolution can be influenced by "proximity" or assembly.